### PR TITLE
Resizable wandering trader

### DIFF
--- a/src/main/java/com/anotherpillow/skyplusplus/config/SkyPlusPlusConfig.java
+++ b/src/main/java/com/anotherpillow/skyplusplus/config/SkyPlusPlusConfig.java
@@ -40,6 +40,8 @@ public class SkyPlusPlusConfig {
 
     @ConfigEntry public int traderX = 16;
     @ConfigEntry public int traderY = 16;
+    @ConfigEntry
+    public int traderSize = 32;
     @ConfigEntry public boolean enableTraderFinder = true;
     @ConfigEntry public boolean enableTraderTitles = true;
 
@@ -165,6 +167,20 @@ public class SkyPlusPlusConfig {
                                 *///?} else {
                                 .controller(opt -> new IntegerSliderController(opt, 0, 4000, 16))
                                  //?}
+                                .build())
+                        .option(Option.createBuilder(int.class)
+                                .name(Text.translatable("skyplusplus.config.trader-size"))
+                                //? if >1.19.2 {
+                                /*.description(OptionDescription.of(Text.translatable("skyplusplus.config.trader-size-desc")))
+                                 *///?} else {
+                                .tooltip(Text.translatable("skyplusplus.config.trader-size-desc"))
+                                //?}
+                                .binding(defaults.traderSize, () -> config.traderSize, v -> config.traderSize = v)
+                                //? if >1.19.2 {
+                                /*.controller(opt -> IntegerSliderControllerBuilder.create(opt).range(8, 128).step(4))
+                                 *///?} else {
+                                .controller(opt -> new IntegerSliderController(opt, 8, 128, 4))
+                                //?}
                                 .build())
                         .build())
                 .category(ConfigCategory.createBuilder()

--- a/src/main/java/com/anotherpillow/skyplusplus/config/SkyPlusPlusConfig.java
+++ b/src/main/java/com/anotherpillow/skyplusplus/config/SkyPlusPlusConfig.java
@@ -40,8 +40,7 @@ public class SkyPlusPlusConfig {
 
     @ConfigEntry public int traderX = 16;
     @ConfigEntry public int traderY = 16;
-    @ConfigEntry
-    public int traderSize = 32;
+    @ConfigEntry public int traderSize = 32;
     @ConfigEntry public boolean enableTraderFinder = true;
     @ConfigEntry public boolean enableTraderTitles = true;
 

--- a/src/main/java/com/anotherpillow/skyplusplus/screen/TraderImage.java
+++ b/src/main/java/com/anotherpillow/skyplusplus/screen/TraderImage.java
@@ -59,9 +59,9 @@ public class TraderImage {
         *///?} else {
         buffer.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR_TEXTURE);
         buffer.vertex(positionMatrix, config.traderX, config.traderY, 0).color(1f, 1f, 1f, 1f).texture(0f, 0f).next();
-        buffer.vertex(positionMatrix, config.traderX, config.traderY + 32, 0).color(1f, 1f, 1f, 1f).texture(0f, 1f).next();
-        buffer.vertex(positionMatrix, config.traderX + 32, config.traderY + 32, 0).color(1f, 1f, 1f, 1f).texture(1f, 1f).next();
-        buffer.vertex(positionMatrix, config.traderX + 32, config.traderY, 0).color(1f, 1f, 1f, 1f).texture(1f, 0f).next();
+        buffer.vertex(positionMatrix, config.traderX, config.traderY + config.traderSize, 0).color(1f, 1f, 1f, 1f).texture(0f, 1f).next();
+        buffer.vertex(positionMatrix, config.traderX + config.traderSize, config.traderY + config.traderSize, 0).color(1f, 1f, 1f, 1f).texture(1f, 1f).next();
+        buffer.vertex(positionMatrix, config.traderX + config.traderSize, config.traderY, 0).color(1f, 1f, 1f, 1f).texture(1f, 0f).next();
          //?}
 
 

--- a/src/main/java/com/anotherpillow/skyplusplus/screen/TraderImage.java
+++ b/src/main/java/com/anotherpillow/skyplusplus/screen/TraderImage.java
@@ -24,9 +24,11 @@ import com.anotherpillow.skyplusplus.config.SkyPlusPlusConfig;
 
 public class TraderImage {
 
-    public static void draw(/*? >=1.21 {*/ /*Matrix3x2f matrixStack *//*?} else {*/ MatrixStack matrixStack /*?}*/) {
+    public static void draw(/*? >=1.21 {*/ /*Matrix3x2f matrixStack *//*?} else {*/MatrixStack matrixStack /*?}*/) {
         // not draw in f1
-        if (SkyPlusPlusClient.client.options.hudHidden) return;
+        if (SkyPlusPlusClient.client.options.hudHidden) {
+            return;
+        }
 
         //? if >=1.21 {
         /*Matrix4f positionMatrix = new Matrix4f();
@@ -34,58 +36,48 @@ public class TraderImage {
 //        positionMatrix.set(matrixStack.get(points));
         boolean b = true;
         if (b) return;
-        *///?} else {
+         *///?} else {
         Matrix4f positionMatrix = matrixStack.peek().getPositionMatrix();
-         //?}
-
-
+        //?}
 
         Tessellator tessellator = Tessellator.getInstance();
 
-
         //? <1.21
-         BufferBuilder buffer = tessellator.getBuffer();
+        BufferBuilder buffer = tessellator.getBuffer();
 
         //? >=1.21
         /*BufferBuilder buffer = tessellator.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_TEXTURE_COLOR);*/
-
         SkyPlusPlusConfig config = SkyPlusPlusConfig.configInstance.getConfig();
 
         //? if >=1.21 {
         /*buffer.vertex(positionMatrix, config.traderX, config.traderY, 0).color(1f, 1f, 1f, 1f).texture(0f, 0f);
-        buffer.vertex(positionMatrix, config.traderX, config.traderY + 32, 0).color(1f, 1f, 1f, 1f).texture(0f, 1f);
-        buffer.vertex(positionMatrix, config.traderX + 32, config.traderY + 32, 0).color(1f, 1f, 1f, 1f).texture(1f, 1f);
-        buffer.vertex(positionMatrix, config.traderX + 32, config.traderY, 0).color(1f, 1f, 1f, 1f).texture(1f, 0f);
-        *///?} else {
+    buffer.vertex(positionMatrix, config.traderX, config.traderY + config.traderSize, 0).color(1f, 1f, 1f, 1f).texture(0f, 1f);
+    buffer.vertex(positionMatrix, config.traderX + config.traderSize, config.traderY + config.traderSize, 0).color(1f, 1f, 1f, 1f).texture(1f, 1f);
+    buffer.vertex(positionMatrix, config.traderX + config.traderSize, config.traderY, 0).color(1f, 1f, 1f, 1f).texture(1f, 0f);
+         *///?} else {
         buffer.begin(VertexFormat.DrawMode.QUADS, VertexFormats.POSITION_COLOR_TEXTURE);
         buffer.vertex(positionMatrix, config.traderX, config.traderY, 0).color(1f, 1f, 1f, 1f).texture(0f, 0f).next();
         buffer.vertex(positionMatrix, config.traderX, config.traderY + config.traderSize, 0).color(1f, 1f, 1f, 1f).texture(0f, 1f).next();
         buffer.vertex(positionMatrix, config.traderX + config.traderSize, config.traderY + config.traderSize, 0).color(1f, 1f, 1f, 1f).texture(1f, 1f).next();
         buffer.vertex(positionMatrix, config.traderX + config.traderSize, config.traderY, 0).color(1f, 1f, 1f, 1f).texture(1f, 0f).next();
-         //?}
-
+        //?}
 
         //? if >1.19.2 {
-
         //?} else {
         RenderSystem.setShader(GameRenderer::getPositionColorTexShader);
-         //?}
-
+        //?}
 
         //? if >1.19.2 {
-
         //?} else {
         RenderSystem.setShaderTexture(0, new Identifier("skyplusplus", "traderhead.png"));
-         //?}
+        //?}
         //? <1.21
-         RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
+        RenderSystem.setShaderColor(1f, 1f, 1f, 1f);
 
         //? if >=1.21 {
         /*buffer.end();
-        *///?} else {
+         *///?} else {
         tessellator.draw();
-         //?}
-
-
+        //?}
     }
 }

--- a/src/main/java/com/anotherpillow/skyplusplus/util/TraderCountdown.java
+++ b/src/main/java/com/anotherpillow/skyplusplus/util/TraderCountdown.java
@@ -20,20 +20,44 @@ import net.minecraft.text.Text;
 
 public class TraderCountdown {
 
-    public static void draw(/*? >=1.20.1 {*/ /*DrawContext ctx *//*?} else {*/ MatrixStack matrixStack /*?}*/, String txt, int textOffset) {
+    public static void draw(/*? >=1.20.1 {*/ /*DrawContext ctx *//*?} else {*/MatrixStack matrixStack /*?}*/, String txt) {
         SkyPlusPlusConfig config = SkyPlusPlusConfig.configInstance.getConfig();
-        // not draw in f1
-        if (SkyPlusPlusClient.client.options.hudHidden) return;
+        if (SkyPlusPlusClient.client.options.hudHidden) {
+            return;
+        }
 
         TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
-        //? if >=1.20.1 {
-        /*ctx.drawCenteredTextWithShadow(textRenderer, txt, config.traderX + 32 + textOffset,config.traderY + 16, 0xFFFFFF);
-        *///?} else if >1.19.2 {
-        /*DrawableHelper.drawCenteredTextWithShadow(matrixStack, textRenderer, txt, config.traderX + 32 + textOffset,config.traderY + 16, 0xFFFFFF);
-        *///?} else {
-        DrawableHelper.drawCenteredText(matrixStack, textRenderer, txt, config.traderX + 32 + textOffset,config.traderY + 16, 0xFFFFFF);
-         //?}
 
+        float scale = Math.max(0.25f, config.traderSize / 32.0f);
+        int textWidth = textRenderer.getWidth(txt);
+
+        float left = config.traderX + config.traderSize + 2.0f;
+        float centerY = config.traderY + (config.traderSize / 2.0f);
+
+        int drawX = Math.round((left / scale) + (textWidth / 2.0f));
+        int drawY = Math.round((centerY / scale) - (textRenderer.fontHeight / 2.0f));
+
+        //? if >=1.21 {
+        /*ctx.getMatrices().pushMatrix();
+    ctx.getMatrices().scale(scale, scale);
+    ctx.drawCenteredTextWithShadow(textRenderer, txt, drawX, drawY, 0xFFFFFF);
+    ctx.getMatrices().popMatrix();
+         *///?} else if >=1.20.1 {
+        /*ctx.getMatrices().push();
+    ctx.getMatrices().scale(scale, scale, 1.0f);
+    ctx.drawCenteredTextWithShadow(textRenderer, txt, drawX, drawY, 0xFFFFFF);
+    ctx.getMatrices().pop();
+         *///?} else if >1.19.2 {
+        /*matrixStack.push();
+    matrixStack.scale(scale, scale, 1.0f);
+    DrawableHelper.drawCenteredTextWithShadow(matrixStack, textRenderer, txt, drawX, drawY, 0xFFFFFF);
+    matrixStack.pop();
+         *///?} else {
+        matrixStack.push();
+        matrixStack.scale(scale, scale, 1.0f);
+        DrawableHelper.drawCenteredText(matrixStack, textRenderer, txt, drawX, drawY, 0xFFFFFF);
+        matrixStack.pop();
+        //?}
     }
 
     private static boolean hasShownTitleForThisMinute = false;
@@ -66,10 +90,8 @@ public class TraderCountdown {
         return "0:" + minutesString;
     }
 
-    public static void DrawCountdown(/*? >=1.20.1 {*/ /*DrawContext ctx *//*?} else {*/ MatrixStack matrixStack /*?}*/) {
+    public static void DrawCountdown(/*? >=1.20.1 {*/ /*DrawContext ctx *//*?} else {*/MatrixStack matrixStack /*?}*/) {
         String txt = Text.translatable("skyplusplus.trader.countdown.timer").getString() + countdown();
-        int textWidth = MinecraftClient.getInstance().textRenderer.getWidth(txt);
-        int textOffset = textWidth / 2;
-        draw(/*? >=1.20.1 {*/ /*ctx *//*?} else {*/ matrixStack /*?}*/, txt, textOffset);
+        draw(/*? >=1.20.1 {*/ /*ctx *//*?} else {*/matrixStack /*?}*/, txt);
     }
 }

--- a/src/main/java/com/anotherpillow/skyplusplus/util/TraderFinder.java
+++ b/src/main/java/com/anotherpillow/skyplusplus/util/TraderFinder.java
@@ -70,10 +70,10 @@ public class TraderFinder {
         int traderY = Integer.parseInt(traderXYZ[1]);
         int traderZ = Integer.parseInt(traderXYZ[2]);
 
-        String txt = String.valueOf(Text.translatable(
+        String txt = Text.translatable(
                 "skyplusplus.trader.location-reveal",
                 convertXYZToLocationName(traderX, traderY, traderZ)
-        ));
+        ).getString();
 
         // Scale text with image size (32 = original baseline scale 1.0)
         float scale = Math.max(0.25f, config.traderSize / 32.0f);

--- a/src/main/java/com/anotherpillow/skyplusplus/util/TraderFinder.java
+++ b/src/main/java/com/anotherpillow/skyplusplus/util/TraderFinder.java
@@ -12,9 +12,9 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.entity.passive.WanderingTraderEntity;
 //? if >=1.20.1 {
 /*import net.minecraft.client.gui.DrawContext;
-*///?} else {
+ *///?} else {
 import net.minecraft.client.gui.DrawableHelper;
- //?}
+//?}
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
@@ -24,6 +24,7 @@ import net.minecraft.util.math.BlockPos;
 import com.anotherpillow.skyplusplus.config.SkyPlusPlusConfig;
 
 public class TraderFinder {
+
     //Trader XYZ to location name
     //X4063, Y174, Z2026 (Warp Grass)
     //X17, Y174, Z44 (Bank)
@@ -54,38 +55,62 @@ public class TraderFinder {
         } else if (x == 4032 && y == 171 && z == 2014) {
             traderLocation = Text.translatable("skyplusplus.trader.location.campfire-walkway");
         } else {
-          traderLocation = Text.translatable("skyplusplus.trader.location.unknown", x, y, z);
+            traderLocation = Text.translatable("skyplusplus.trader.location.unknown", x, y, z);
         }
 
         return traderLocation.getString();
     }
 
-    public static void showTraderString(/*? >=1.20.1 {*/ /*DrawContext ctx *//*?} else {*/ MatrixStack matrixStack /*?}*/) {
+    public static void showTraderString(/*? >=1.20.1 {*/ /*DrawContext ctx *//*?} else {*/MatrixStack matrixStack /*?}*/) {
         SkyPlusPlusConfig config = SkyPlusPlusConfig.configInstance.getConfig();
-
 
         TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
         String[] traderXYZ = traderXYZString.split(",");
         int traderX = Integer.parseInt(traderXYZ[0]);
         int traderY = Integer.parseInt(traderXYZ[1]);
         int traderZ = Integer.parseInt(traderXYZ[2]);
-        //String txt = "Trader at: " + traderX + ", " + traderY + ", " + traderZ;
-        String txt = String.valueOf(Text.translatable("skyplusplus.trader.location-reveal", convertXYZToLocationName(traderX, traderY, traderZ)));
 
+        String txt = String.valueOf(Text.translatable(
+                "skyplusplus.trader.location-reveal",
+                convertXYZToLocationName(traderX, traderY, traderZ)
+        ));
+
+        // Scale text with image size (32 = original baseline scale 1.0)
+        float scale = Math.max(0.25f, config.traderSize / 32.0f);
         int textWidth = textRenderer.getWidth(txt);
-        int textOffset = textWidth / 2;
 
-        //? if >=1.20.1 {
-        /*ctx.drawCenteredTextWithShadow(textRenderer, txt, config.traderX + 32 + textOffset,config.traderY + 16, 0xFFFFFF);
-        *///?} else if >1.19.2 {
-        /*DrawableHelper.drawCenteredTextWithShadow(matrixStack, textRenderer, txt, config.traderX + 32 + textOffset,config.traderY + 16, 0xFFFFFF);
+        // Position text to the right of the image, vertically centered with the image
+        float left = config.traderX + config.traderSize + 2.0f;
+        float centerY = config.traderY + (config.traderSize / 2.0f);
+
+        // Convert to coordinates in the scaled matrix space
+        int drawX = Math.round((left / scale) + (textWidth / 2.0f));
+        int drawY = Math.round((centerY / scale) - (textRenderer.fontHeight / 2.0f));
+
+        //? if >=1.21 {
+/*ctx.getMatrices().pushMatrix();
+ctx.getMatrices().scale(scale, scale);
+ctx.drawCenteredTextWithShadow(textRenderer, txt, drawX, drawY, 0xFFFFFF);
+ctx.getMatrices().popMatrix();
+         *///?} else if >=1.20.1 {
+/*ctx.getMatrices().push();
+ctx.getMatrices().scale(scale, scale, 1.0f);
+ctx.drawCenteredTextWithShadow(textRenderer, txt, drawX, drawY, 0xFFFFFF);
+ctx.getMatrices().pop();
+         *///?} else if >1.19.2 {
+/*matrixStack.push();
+matrixStack.scale(scale, scale, 1.0f);
+DrawableHelper.drawCenteredTextWithShadow(matrixStack, textRenderer, txt, drawX, drawY, 0xFFFFFF);
+matrixStack.pop();
          *///?} else {
-        DrawableHelper.drawCenteredText(matrixStack, textRenderer, txt, config.traderX + 32 + textOffset,config.traderY + 16, 0xFFFFFF);
-         //?}
-
+        matrixStack.push();
+        matrixStack.scale(scale, scale, 1.0f);
+        DrawableHelper.drawCenteredText(matrixStack, textRenderer, txt, drawX, drawY, 0xFFFFFF);
+        matrixStack.pop();
+//?}
     }
 
-    public static void loopTraders(/*? >=1.20.1 {*/ /*DrawContext ctx *//*?} else {*/ MatrixStack matrixStack /*?}*/) {
+    public static void loopTraders(/*? >=1.20.1 {*/ /*DrawContext ctx *//*?} else {*/MatrixStack matrixStack /*?}*/) {
         MinecraftClient client = MinecraftClient.getInstance();
         Camera camera = MinecraftClient.getInstance().gameRenderer.getCamera();
 
@@ -98,19 +123,22 @@ public class TraderFinder {
                 int traderZ = (int) entity.getZ();
 
                 setTraderXYZString(traderX, traderY, traderZ);
-                showTraderString(/*? >=1.20.1 {*/ /*ctx *//*?} else {*/ matrixStack /*?}*/);
+                showTraderString(/*? >=1.20.1 {*/ /*ctx *//*?} else {*/matrixStack /*?}*/);
             }
         }
 
     }
-    public static void findTrader(/*? >=1.20.1 {*/ /*DrawContext ctx *//*?} else {*/ MatrixStack matrixStack /*?}*/) {
+
+    public static void findTrader(/*? >=1.20.1 {*/ /*DrawContext ctx *//*?} else {*/MatrixStack matrixStack /*?}*/) {
         MinecraftClient mc = MinecraftClient.getInstance();
         Entity player = mc.player;
 
-        if (player == null || mc.world == null) return;
+        if (player == null || mc.world == null) {
+            return;
+        }
 
         BlockPos playerPos = player.getBlockPos();
-        loopTraders(/*? >=1.20.1 {*/ /*ctx *//*?} else {*/ matrixStack /*?}*/);
+        loopTraders(/*? >=1.20.1 {*/ /*ctx *//*?} else {*/matrixStack /*?}*/);
 
     }
 }

--- a/src/main/resources/assets/skyplusplus/lang/en_us.json
+++ b/src/main/resources/assets/skyplusplus/lang/en_us.json
@@ -37,8 +37,8 @@
   "skyplusplus.config.trader-notif-x-desc": "X Position",
   "skyplusplus.config.trader-notif-y": "Notification Y",
   "skyplusplus.config.trader-notif-y-desc": "Y Position",
-  "skyplusplus.config.trader-size": "Image Size",
-  "skyplusplus.config.trader-size-desc": "Size of the Wandering Trader image in pixels",
+  "skyplusplus.config.trader-size": "Size",
+  "skyplusplus.config.trader-size-desc": "Scales the wandering trader image and the text beside it.",
 
   "skyplusplus.config.chatfilter.title": "Filter Chat",
   "skyplusplus.config.chatfilter.hidevisitmsgs": "Hide Visiting Messages",

--- a/src/main/resources/assets/skyplusplus/lang/en_us.json
+++ b/src/main/resources/assets/skyplusplus/lang/en_us.json
@@ -37,6 +37,8 @@
   "skyplusplus.config.trader-notif-x-desc": "X Position",
   "skyplusplus.config.trader-notif-y": "Notification Y",
   "skyplusplus.config.trader-notif-y-desc": "Y Position",
+  "skyplusplus.config.trader-size": "Image Size",
+  "skyplusplus.config.trader-size-desc": "Size of the Wandering Trader image in pixels",
 
   "skyplusplus.config.chatfilter.title": "Filter Chat",
   "skyplusplus.config.chatfilter.hidevisitmsgs": "Hide Visiting Messages",


### PR DESCRIPTION
- Added `skyplusplus.config.trader-size`
  - resizes & scales the image and text
  
**Example scale `16` px (rather than default `32`)**:

<table>
  <tr>
    <th>config</th>
    <th>the experience</th>
  </tr>
  <tr>
    <td><img src="https://i.gyazo.com/3a0f56d36d2f11c4bb8aac2e3328c55e.png" alt="config GUI settings" width="350" /></td>
    <td><img src="https://i.gyazo.com/ec9571eb1f4406260ad21e965a4d47fb.jpg" alt="in game experience" width="350"/></td>
  </tr>
</table>

> **note:** [`pl_pl.json`](https://github.com/AnotherPillow/SkyPlusPlus/blob/main/src/main/resources/assets/skyplusplus/lang/pl_pl.json) not updated.... im sorry Poland

<!-- amazing mod can't play .net without it 💯 --!>